### PR TITLE
feat(fleet): enable fleet registry heartbeats

### DIFF
--- a/.github/maintainer/config.yml
+++ b/.github/maintainer/config.yml
@@ -108,6 +108,22 @@ escalation:
   stale_days: 7
   labels: ['maintainer:escalated']
 
+# ── Fleet Registry ────────────────────────────────────────────────────────────
+# Register this repo with the caretaker admin dashboard. When enabled, the
+# orchestrator POSTs a heartbeat to the central registry after every run so
+# the fleet page at https://caretaker.cat-herding.net shows live status.
+#
+# Requirements:
+#   1. Set CARETAKER_FLEET_SECRET as a GitHub Actions secret in this repo.
+#   2. Ensure your workflow exports CARETAKER_FLEET_SECRET (v0.19.6+ templates
+#      do this automatically; older installs need a one-line workflow edit).
+fleet_registry:
+  enabled: true
+  endpoint: https://caretaker.cat-herding.net/api/fleet/heartbeat
+  secret_env: CARETAKER_FLEET_SECRET
+  timeout_seconds: 5.0
+  include_full_summary: false
+
 llm:
   claude_enabled: auto
   claude_features:

--- a/.github/workflows/maintainer.yml
+++ b/.github/workflows/maintainer.yml
@@ -122,6 +122,7 @@ jobs:
           CARETAKER_EVENT_PAYLOAD: ${{ toJSON(github.event) }}
           CARETAKER_RUN_MODE: ${{ github.event.inputs.mode || 'full' }}
           CARETAKER_EVENT_TYPE: ${{ github.event_name }}
+          CARETAKER_FLEET_SECRET: ${{ secrets.CARETAKER_FLEET_SECRET }}
         run: |
           caretaker run \
             --config .github/maintainer/config.yml \
@@ -166,6 +167,7 @@ jobs:
           COPILOT_PAT: ${{ secrets.COPILOT_PAT }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CARETAKER_FAILED_RUN_ID: ${{ github.run_id }}
+          CARETAKER_FLEET_SECRET: ${{ secrets.CARETAKER_FLEET_SECRET }}
           CARETAKER_EVENT_PAYLOAD: >-
             {
               "workflow_run": {


### PR DESCRIPTION
## Fleet Registry Opt-in

This PR enables this repo to send heartbeats to the caretaker admin dashboard, so its status shows up in the Fleet view at https://caretaker.cat-herding.net.

### What changes
- `.github/maintainer/config.yml`: adds `fleet_registry:` block (`enabled: true`, prod endpoint)
- `.github/workflows/maintainer.yml`: adds `CARETAKER_FLEET_SECRET` to env blocks

### What you need to do
1. **Add the secret**: Go to this repo's Settings → Secrets and variables → Actions → New repository secret, name it `CARETAKER_FLEET_SECRET`. Get the value from the caretaker admin.
2. **Merge this PR**: Once merged and the next workflow run completes, a heartbeat will appear at https://caretaker.cat-herding.net/fleet.

After merging, you can trigger a test immediately via the workflow's `workflow_dispatch` button.

Part of caretaker v0.19.6 fleet registry opt-in.
